### PR TITLE
formatting: use frg::expected in formatting agents

### DIFF
--- a/include/frg/expected.hpp
+++ b/include/frg/expected.hpp
@@ -2,6 +2,7 @@
 
 #include <new>
 #include <utility>
+#include <type_traits>
 
 #include <frg/macros.hpp>
 


### PR DESCRIPTION
this is an API breaking change, maybe i should also finish using ``frg::expected`` for the formatters as well before we merge this to avoid having to break the API again at a later stage?