### PR TITLE
allocation: Add stddef include to get size_t

### DIFF
--- a/include/frg/allocation.hpp
+++ b/include/frg/allocation.hpp
@@ -6,6 +6,8 @@
 
 #include <frg/macros.hpp>
 
+#include <stddef.h>
+
 namespace frg FRG_VISIBILITY {
 
 template<typename T, typename Allocator, typename... Args>


### PR DESCRIPTION
This is required under gcc 11.