### PR TITLE
printf: fix positional arguments

### DIFF
--- a/include/frg/printf.hpp
+++ b/include/frg/printf.hpp
@@ -92,7 +92,7 @@ frg::expected<format_error> printf_format(A agent, const char *s, va_struct *vsp
 		format_options opts;
 		while(true) {
 			if (*s >= '0' && *s <= '9' && s[1] && s[1] == '$') {
-				opts.arg_pos = *s - '0';
+				opts.arg_pos = *s - '0' - 1; // args are 1-indexed
 				s += 2;
 				FRG_ASSERT(*s);
 			} else if(*s == '-') {


### PR DESCRIPTION
POSIX positional arguments are 1-indexed but the current code wrongly assumes that they're 0-indexed.

Fixes https://github.com/managarm/frigg/issues/16.
