### PR TITLE
formatting: add support for binary, octal and alternative decimal format specifiers

### DIFF
--- a/include/frg/formatting.hpp
+++ b/include/frg/formatting.hpp
@@ -54,6 +54,8 @@ private:
 
 enum class format_conversion {
 	null,
+	binary,
+	octal,
 	decimal,
 	hex
 };
@@ -219,6 +221,10 @@ namespace _fmt_basics {
 		int radix = 10;
 		if(fo.conversion == format_conversion::hex) {
 			radix = 16;
+		}else if(fo.conversion == format_conversion::octal) {
+			radix = 8;
+		}else if(fo.conversion == format_conversion::binary) {
+			radix = 2;
 		}else{
 			FRG_ASSERT(fo.conversion == format_conversion::null
 					|| fo.conversion == format_conversion::decimal);
@@ -524,7 +530,7 @@ namespace detail_ {
 		}
 
 		// Format specifier syntax:
-		// ([0-9]+)?(:0?[0-9]*[dXx]?)?
+		// ([0-9]+)?(:0?[0-9]*[bdioXx]?)?
 		bool parse_fmt_spec(frg::string_view spec, size_t &pos, format_options &fo) const {
 			enum class modes {
 				pos, fill, width, conv
@@ -565,6 +571,9 @@ namespace detail_ {
 							fo.minimum_width += spec[i] - '0';
 						} else {
 							switch (spec[i]) {
+								case 'b': fo.conversion = format_conversion::binary; break;
+								case 'o': fo.conversion = format_conversion::octal; break;
+								case 'i':
 								case 'd': fo.conversion = format_conversion::decimal; break;
 								case 'X': fo.use_capitals = true; [[fallthrough]];
 								case 'x': fo.conversion = format_conversion::hex; break;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -176,8 +176,29 @@ TEST(formatting, fmt) {
 	EXPECT_EQ(str, "10 30");
 	str.clear();
 
+	x = 20;
+	frg::output_to(str) << frg::fmt("{:d} {:i}", x, x + 20);
+	EXPECT_EQ(str, "20 40");
+	str.clear();
+
 	frg::output_to(str) << frg::fmt("{:08X}", 0xAAABBB);
 	EXPECT_EQ(str, "00AAABBB");
+	str.clear();
+
+	frg::output_to(str) << frg::fmt("{:b}", 0b101010);
+	EXPECT_EQ(str, "101010");
+	str.clear();
+
+	frg::output_to(str) << frg::fmt("{:08b}", 0b101010);
+	EXPECT_EQ(str, "00101010");
+	str.clear();
+
+	frg::output_to(str) << frg::fmt("{:o}", 0777);
+	EXPECT_EQ(str, "777");
+	str.clear();
+
+	frg::output_to(str) << frg::fmt("{:03o}", 077);
+	EXPECT_EQ(str, "077");
 	str.clear();
 
 	frg::output_to(str) << frg::fmt("{1} {0}", 3, 4);


### PR DESCRIPTION
This pr adds support for 'b', 'o' and 'i' format specifiers
Example:
```
("{:b}", 28) -> 11100 // 0b11100
("{:o}", 28) -> 34 // 034
("{:i}", 28) -> 28 // 28
```