### PR TITLE
formatting: allow passing no additional arguments to frg::fmt

### DIFF
--- a/include/frg/formatting.hpp
+++ b/include/frg/formatting.hpp
@@ -517,7 +517,7 @@ namespace detail_ {
 		frg::string_view fmt;
 		frg::tuple<Ts...> args;
 
-		template <typename F>
+		template <typename F> requires (sizeof...(Ts) > 0)
 		bool format_nth(size_t n, format_options fo, F &formatter) const {
 			if (n >= sizeof...(Ts))
 				return false;
@@ -527,6 +527,11 @@ namespace detail_ {
 					? (format(args.template get<I>(), fo, formatter), false)
 					: true) && ...);
 			}(std::make_index_sequence<sizeof...(Ts)>{});
+		}
+
+		template <typename F>
+		bool format_nth(size_t, format_options, F &) const {
+			return false;
 		}
 
 		// Format specifier syntax:


### PR DESCRIPTION
This commit fixes error ``no member named 'get' in 'frg::tuple<>'`` which is thrown when no additional arguments are passed to frg::fmt Example:
```c++
frg::fmt("my text with additional {}", "args");
frg::fmt("my text"); // < error here
```