### PR TITLE
formatting: support formatting characters

### DIFF
--- a/include/frg/formatting.hpp
+++ b/include/frg/formatting.hpp
@@ -384,6 +384,11 @@ void format_object(double object, format_options fo, F &formatter) {
 }
 
 template<typename F>
+void format_object(char object, format_options, F &formatter) {
+	formatter.append(object);
+}
+
+template<typename F>
 void format_object(const char *object, format_options, F &formatter) {
 	formatter.append(object);
 }


### PR DESCRIPTION
this commit adds support for formatting characters
Example:
```c++
frg::fmt("character: {}, other character: {}", 'c', 'f');
```