### PR TITLE
formatting: support formatting characters

### DIFF
--- a/include/frg/eternal.hpp
+++ b/include/frg/eternal.hpp
@@ -28,7 +28,12 @@ using aligned_union = aligned_storage<
 template<typename T>
 class eternal {
 public:
-	static_assert(__has_trivial_destructor(aligned_storage<sizeof(T), alignof(T)>),
+	static_assert(
+#if defined(__clang__) && __clang_major__ >= 15
+		__is_trivially_destructible(aligned_storage<sizeof(T), alignof(T)>),
+#else
+		__has_trivial_destructor(aligned_storage<sizeof(T), alignof(T)>),
+#endif
 			"eternal<T> should have a trivial destructor");
 
 	template<typename... Args>

--- a/include/frg/formatting.hpp
+++ b/include/frg/formatting.hpp
@@ -54,6 +54,7 @@ private:
 
 enum class format_conversion {
 	null,
+	character,
 	binary,
 	octal,
 	decimal,
@@ -384,6 +385,15 @@ void format_object(double object, format_options fo, F &formatter) {
 }
 
 template<typename F>
+void format_object(char object, format_options fo, F &formatter) {
+	if(fo.conversion == format_conversion::character) {
+		formatter.append(object);
+		return;
+	}
+	_fmt_basics::format_integer(object, fo, formatter);
+}
+
+template<typename F>
 void format_object(const char *object, format_options, F &formatter) {
 	formatter.append(object);
 }
@@ -535,7 +545,7 @@ namespace detail_ {
 		}
 
 		// Format specifier syntax:
-		// ([0-9]+)?(:0?[0-9]*[bdioXx]?)?
+		// ([0-9]+)?(:0?[0-9]*[bcdioXx]?)?
 		bool parse_fmt_spec(frg::string_view spec, size_t &pos, format_options &fo) const {
 			enum class modes {
 				pos, fill, width, conv
@@ -577,6 +587,7 @@ namespace detail_ {
 						} else {
 							switch (spec[i]) {
 								case 'b': fo.conversion = format_conversion::binary; break;
+								case 'c': fo.conversion = format_conversion::character; break;
 								case 'o': fo.conversion = format_conversion::octal; break;
 								case 'i':
 								case 'd': fo.conversion = format_conversion::decimal; break;


### PR DESCRIPTION
this pr adds support for formatting characters and fixes this warning on clang 15:
```
builtin __has_trivial_destructor is deprecated; use __is_trivially_destructible instead
```
Example:
```c++
frg::fmt("character: {:c}, int: {}, int: {}, int: 0x{:X}", 'c', uint8_t('c'), 'c', 'c');
```
```
character: c, int: 99, int: 99, int 0x63
```