### PR TITLE
eternal: add missing include

### DIFF
--- a/include/frg/eternal.hpp
+++ b/include/frg/eternal.hpp
@@ -2,6 +2,7 @@
 #define FRG_ETERNAL_HPP
 
 #include <new>
+#include <cstddef>
 #include <utility>
 #include <algorithm>
 
@@ -9,7 +10,7 @@
 
 namespace frg FRG_VISIBILITY {
 
-template<size_t Size, size_t Align>
+template<std::size_t Size, std::size_t Align>
 struct alignas(Align) aligned_storage {
 	constexpr aligned_storage()
 	: buffer{0} { }


### PR DESCRIPTION
this commit adds missing #include <cstddef> in eternal.hpp
eternal.hpp relies on cxxshim/{utility|algorithm|new} including stddef.h,
but unlike cxxshim, libstdc++ does not do that, so it throws an error
about missing size_t