### PR TITLE
Implement std::size and std::ssize for C-style arrays

### DIFF
--- a/include/frg/array.hpp
+++ b/include/frg/array.hpp
@@ -128,6 +128,18 @@ constexpr auto array_concat(const Ts &...arrays) {
 
 namespace std {
 
+template <class T, size_t N>
+constexpr size_t size(const T (&array)[N]) noexcept
+{
+    return N;
+}
+
+template <class T, ptrdiff_t N>
+constexpr ptrdiff_t ssize(const T (&array)[N]) noexcept
+{
+    return N;
+}
+
 template<size_t I, class T, size_t N>
 constexpr T &get(frg::array<T, N> &a) noexcept {
 	static_assert(I < N, "array index is not within bounds");


### PR DESCRIPTION
C++17 and C++20 defines template functions for deducing the size of C-style arrays. I've found this useful and the implementation is simple (pretty much identical to the implementation on [cppreference](https://en.cppreference.com/w/cpp/iterator/size)).