### PR TITLE
Revert "logging: Do not use iostream under any circumstances"

### DIFF
--- a/include/frg/logging.hpp
+++ b/include/frg/logging.hpp
@@ -6,6 +6,13 @@
 #include <frg/macros.hpp>
 #include <frg/detection.hpp>
 
+#if __STDC_HOSTED__
+#	if __has_include(<iostream>)
+#		include <iostream>
+#		define FRIGG_HAS_IOSTREAM
+#	endif
+#endif
+
 namespace frg FRG_VISIBILITY {
 
 struct endlog_t { };
@@ -158,7 +165,11 @@ struct ostream_out {
 	}
 
 	auto &operator<<(endlog_t) {
+#ifdef FRIGG_HAS_IOSTREAM
+		output << std::endl;
+#else
 		output << '\n';
+#endif // FRIGG_HAS_IOSTREAM
 		return *this;
 	}
 };


### PR DESCRIPTION
Reverts managarm/frigg#67

this broke at least one reverse dependency - please think of non-destructive methodology next time