### PR TITLE
array: Fix structured bindings

### DIFF
--- a/include/frg/array.hpp
+++ b/include/frg/array.hpp
@@ -124,10 +124,6 @@ constexpr auto array_concat(const Ts &...arrays) {
 	return res;
 }
 
-} // namespace frg
-
-namespace std {
-
 template<size_t I, class T, size_t N>
 constexpr T &get(frg::array<T, N> &a) noexcept {
 	static_assert(I < N, "array index is not within bounds");
@@ -151,6 +147,10 @@ constexpr const T &&get(const frg::array<T, N> &&a) noexcept {
 	static_assert(I < N, "array index is not within bounds");
 	return std::move(a[I]);
 };
+
+} // namespace frg
+
+namespace std {
 
 template<class T, size_t N>
 struct tuple_size<frg::array<T, N>> :

--- a/include/frg/array.hpp
+++ b/include/frg/array.hpp
@@ -152,30 +152,6 @@ constexpr const T &&get(const frg::array<T, N> &&a) noexcept {
 
 namespace std {
 
-template<size_t I, class T, size_t N>
-constexpr T &get(frg::array<T, N> &a) noexcept {
-	static_assert(I < N, "array index is not within bounds");
-	return a[I];
-};
-
-template<size_t I, class T, size_t N>
-constexpr T &&get(frg::array<T, N> &&a) noexcept {
-	static_assert(I < N, "array index is not within bounds");
-	return std::move(a[I]);
-};
-
-template<size_t I, class T, size_t N>
-constexpr const T &get(const frg::array<T, N> &a) noexcept {
-	static_assert(I < N, "array index is not within bounds");
-	return a[I];
-};
-
-template<size_t I, class T, size_t N>
-constexpr const T &&get(const frg::array<T, N> &&a) noexcept {
-	static_assert(I < N, "array index is not within bounds");
-	return std::move(a[I]);
-};
-
 template<class T, size_t N>
 struct tuple_size<frg::array<T, N>> :
 	integral_constant<size_t, N> { };

--- a/include/frg/array.hpp
+++ b/include/frg/array.hpp
@@ -152,6 +152,30 @@ constexpr const T &&get(const frg::array<T, N> &&a) noexcept {
 
 namespace std {
 
+template<size_t I, class T, size_t N>
+constexpr T &get(frg::array<T, N> &a) noexcept {
+	static_assert(I < N, "array index is not within bounds");
+	return a[I];
+};
+
+template<size_t I, class T, size_t N>
+constexpr T &&get(frg::array<T, N> &&a) noexcept {
+	static_assert(I < N, "array index is not within bounds");
+	return std::move(a[I]);
+};
+
+template<size_t I, class T, size_t N>
+constexpr const T &get(const frg::array<T, N> &a) noexcept {
+	static_assert(I < N, "array index is not within bounds");
+	return a[I];
+};
+
+template<size_t I, class T, size_t N>
+constexpr const T &&get(const frg::array<T, N> &&a) noexcept {
+	static_assert(I < N, "array index is not within bounds");
+	return std::move(a[I]);
+};
+
 template<class T, size_t N>
 struct tuple_size<frg::array<T, N>> :
 	integral_constant<size_t, N> { };

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -149,6 +149,32 @@ TEST(tuples, reference_test) {
 	EXPECT_EQ(&z, &t2.get<2>());
 }
 
+#include <frg/array.hpp>
+
+TEST(array, basic_test) {
+    constexpr int N = 4;
+    frg::array<int, N> arr{0, 1, 2, 3};
+    for (int i = 0; i < N; i++)
+        EXPECT_EQ(arr[i], i);
+
+    const auto [a, b, c, d] = arr;
+    EXPECT_EQ(a, 0);
+    EXPECT_EQ(b, 1);
+    EXPECT_EQ(c, 2);
+    EXPECT_EQ(d, 3);
+
+    arr[0] = 1;
+    EXPECT_NE(a, arr[0]); // Make sure a doesn't change when array changes
+
+    const auto& [e, f, g, h] = arr;
+    EXPECT_EQ(e, 1);
+    arr[0] = 2;
+    EXPECT_EQ(e, 2); // Make sure e does change when array changes
+    
+    static_assert(std::tuple_size_v<decltype(arr)> == N, "tuple_size produces wrong result");
+    static_assert(std::is_same_v<std::tuple_element_t<N, decltype(arr)>, int>, "tuple_element produces wrong result");
+}
+
 #include <frg/formatting.hpp>
 #include <frg/logging.hpp>
 #include <string> // std::string


### PR DESCRIPTION
Moves all get overloads for frg::array to frg namespace as Clang and GCC expect get to be in inner type's namespace. More info [here](https://en.cppreference.com/w/cpp/language/structured_binding) in Case 2.