### PR TITLE
printf: Fix a bug in float printing

### DIFF
--- a/include/frg/formatting.hpp
+++ b/include/frg/formatting.hpp
@@ -299,16 +299,11 @@ namespace _fmt_basics {
 		n = static_cast<uint64_t>(number);
 		number -= n;
 		int i = 0;
-		while (n > 0 && i < precision) {
+		while (i < precision) {
 			sink.append('0' + n);
 			number *= 10;
 			n = static_cast<uint64_t>(number);
 			number -= n;
-			i++;
-		}
-
-		while (i < precision) {
-			sink.append('0');
 			i++;
 		}
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -293,6 +293,9 @@ TEST(formatting, printf) {
 				case 'd': case 'i': case 'o': case 'x': case 'X': case 'b': case 'B': case 'u':
 					frg::do_printf_ints(*sink_, t, opts, szmod, vsp_);
 					break;
+				case 'f':
+					frg::do_printf_floats(*sink_, t, opts, szmod, vsp_);
+					break;
 				default:
 					// Should not be reached
 					ADD_FAILURE();
@@ -365,6 +368,10 @@ TEST(formatting, printf) {
 	do_test("0", "%#x", 0);
 	do_test("0", "%#X", 0);
 	do_test("0", "%#o", 0);
+
+	// Test 'f'.
+	do_test("1.100000", "%f", 1.1);
+	do_test("0.01", "%.2f", 0.01234);
 
 	// Test 'd' with different size mods to see
 	// if they work


### PR DESCRIPTION
The current code fails for eg. 5.01 printing 5.000000 instead of 5.010000.