### PR TITLE
spinlock: Fix ticket_spinlock::is_locked check

### DIFF
--- a/include/frg/spinlock.hpp
+++ b/include/frg/spinlock.hpp
@@ -42,8 +42,8 @@ struct ticket_spinlock {
 	}
 
 	bool is_locked() {
-		return (__atomic_load_n(&serving_ticket_, __ATOMIC_RELAXED) + 1)
-			== __atomic_load_n(&next_ticket_, __ATOMIC_RELAXED);
+		return __atomic_load_n(&serving_ticket_, __ATOMIC_RELAXED)
+			< __atomic_load_n(&next_ticket_, __ATOMIC_RELAXED);
 	}
 
 	void unlock() {


### PR DESCRIPTION
If multiple waiters call ::lock, next_ticket_ is pushed forward multiple times.