### PR TITLE
scope_exit: Add STL-like scope_exit class

### DIFF
--- a/include/frg/scope_exit.hpp
+++ b/include/frg/scope_exit.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <utility>
+
+#include <frg/macros.hpp>
+
+namespace frg FRG_VISIBILITY {
+
+template<typename Fn>
+struct scope_exit {
+	explicit scope_exit(Fn fn)
+	: fn_{std::move(fn)}, active_{true} {}
+
+	scope_exit(const scope_exit &) = delete;
+	scope_exit operator=(const scope_exit &) = delete;
+
+	~scope_exit() {
+		if (active_)
+			fn_();
+	}
+
+	void release() {
+		active_ = false;
+	}
+
+private:
+	Fn fn_;
+	bool active_;
+};
+
+} // namespace frg

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ if not get_option('frigg_no_install')
 		'include/frg/random.hpp',
 		'include/frg/rbtree.hpp',
 		'include/frg/rcu_radixtree.hpp',
+		'include/frg/scope_exit.hpp',
 		'include/frg/slab.hpp',
 		'include/frg/small_vector.hpp',
 		'include/frg/span.hpp',


### PR DESCRIPTION
This class behaves similarly to `std::experimental::scope_exit`, see also: https://en.cppreference.com/w/cpp/experimental/scope_exit