### PR TITLE
expected: added missing return statement

### DIFF
--- a/include/frg/expected.hpp
+++ b/include/frg/expected.hpp
@@ -97,6 +97,7 @@ struct [[nodiscard]] expected : destructor_crtp<E, T> {
 				std::launder(reinterpret_cast<T *>(stor_))->~T();
 			e_ = other.e_;
 		}
+		return *this;
 	}
 
 	expected &operator= (expected &&other) {


### PR DESCRIPTION
Hey - I noticed a missing return in the copy assignment operator for frigg's `expected<>` implementation. 