### PR TITLE
span: allow construction from an array

### DIFF
--- a/include/frg/span.hpp
+++ b/include/frg/span.hpp
@@ -3,6 +3,7 @@
 #include <stddef.h>
 
 #include <frg/macros.hpp>
+#include <frg/array.hpp>
 
 namespace frg FRG_VISIBILITY {
 
@@ -13,6 +14,14 @@ struct span {
 
 	span(T *p, size_t n)
 	: p_{p}, n_{n} { }
+
+	template<typename U, size_t N>
+	span(const array<U, N> &arr)
+	: p_{arr.data()}, n_{N} { }
+
+	template<typename U, size_t N>
+	span(array<U, N> &arr)
+	: p_{arr.data()}, n_{N} { }
 
 	T *data() const {
 		return p_;


### PR DESCRIPTION
Add an array constructor to span, it is already possible using the begin + size constructor but it this is more convenient to use.