### PR TITLE
meson: Make gtest a non-required disabler dependency

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-gtest = dependency('gtest_main')
+gtest = dependency('gtest_main', required: false, disabler: true)
 
 test_executable = executable('frigg_tests',
 	'tests.cpp',


### PR DESCRIPTION
This means when gtest is not found, meson will stop building tests. Useful for packaging frigg without depending on gtest.