### PR TITLE
Fix float and double printing

### DIFF
--- a/include/frg/formatting.hpp
+++ b/include/frg/formatting.hpp
@@ -356,12 +356,12 @@ void format_object(long long object, format_options fo, S &sink) {
 
 template<Sink S>
 void format_object(float object, format_options fo, S &sink) {
-	_fmt_basics::format_integer(object, fo, sink);
+	_fmt_basics::format_float(object, fo, sink);
 }
 
 template<Sink S>
 void format_object(double object, format_options fo, S &sink) {
-	_fmt_basics::format_integer(object, fo, sink);
+	_fmt_basics::format_float(object, fo, sink);
 }
 
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -252,6 +252,10 @@ TEST(formatting, fmt) {
 	EXPECT_EQ(str, "{:h}");
 	str.clear();
 
+	frg::output_to(str) << frg::fmt("{}", 1.5);
+	EXPECT_EQ(str, "1.500000");
+	str.clear();
+
 	std::string abc_def { "abc def" };
 	std::vector<char> abc_def_v { abc_def.cbegin(), abc_def.cend() };
 


### PR DESCRIPTION
This seemed like a copy-paste error.

I tried adding a test, but the test target doesn't compile for me and I didn't look into it further.

macOS 15.3.2
googletest 1.17.0