### PR TITLE
formatting: Test with imprecise float

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -256,8 +256,8 @@ TEST(formatting, fmt) {
 	EXPECT_EQ(str, "1.500000");
 	str.clear();
 
-	frg::output_to(str) << frg::fmt("{}", 1.44f);
-	EXPECT_EQ(str, "1.440000");
+	frg::output_to(str) << frg::fmt("{}", 1.43f);
+	EXPECT_EQ(str, "1.429999");
 	str.clear();
 
 #ifdef FRG_HAS_RANGES


### PR DESCRIPTION
Sorry, I was wrong with my suggestion here: https://github.com/managarm/frigg/pull/91#discussion_r2314571438

While 1.44 can't be exactly represented, the first six digits after the decimal point happen to still be zero, which defeats the point of testing an imprecise value. For better test coverage, use a value like 1.43, which is actually imprecise enough that the first six digits are different from the literal that appears in the C++ code. (See: https://float.exposed/0x3fb70a3d)