### PR TITLE
macros: add FRG_NO_UNIQUE_ADDRESS macro

### DIFF
--- a/include/frg/allocation.hpp
+++ b/include/frg/allocation.hpp
@@ -103,7 +103,7 @@ struct unique_memory {
 private:
 	void *pointer_;
 	size_t size_;
-	[[no_unique_address]] Allocator allocator_;
+	FRG_NO_UNIQUE_ADDRESS Allocator allocator_;
 };
 
 } // namespace frg

--- a/include/frg/macros.hpp
+++ b/include/frg/macros.hpp
@@ -41,4 +41,12 @@ extern "C" {
 	}\
 } while(0)
 
+#if __has_cpp_attribute(msvc::no_unique_address)
+#define FRG_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#elif __has_cpp_attribute(no_unique_address)
+#define FRG_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define FRG_NO_UNIQUE_ADDRESS
+#endif
+
 #endif // FRG_MACROS_HPP

--- a/include/frg/shared_ptr.hpp
+++ b/include/frg/shared_ptr.hpp
@@ -80,7 +80,7 @@ struct intrusive_shared_ptr {
 
 private:
 	T *ptr_{nullptr};
-	[[no_unique_address]] Allocator alloc_{};
+	FRG_NO_UNIQUE_ADDRESS Allocator alloc_{};
 };
 
 template<typename T, typename Allocator, typename... Args>


### PR DESCRIPTION
This is needed as some compilers do not support the C++20 attribute [[no_unique_address]] yet; MSVC is notable. However, clang in Windows or UEFI targets does also not recognize this; work around it by using this macro instead.