### PR TITLE
sharded_slab: Use same size classes as slab_pool

### DIFF
--- a/include/frg/sharded_slab.hpp
+++ b/include/frg/sharded_slab.hpp
@@ -39,36 +39,14 @@ concept Policy = requires(P policy, void *p, size_t size) {
 // as long as the policy is identical.
 template<Policy P>
 struct pool {
+	using policy_traits = slab_policy_traits<P>;
+
 	static constexpr size_t page_size = 4096;
 	static constexpr size_t chunk_boundary = 1 << 18;
 	static constexpr size_t chunk_size = chunk_boundary;
 
 	// TODO: We may want to make this dependent on the number of objects in the chunk.
 	static constexpr size_t reactivate_threshold = 8;
-
-	// Size classes are powers of two from 16 to 4096.
-	// TODO: Adopt the same size classes as the original slab code.
-	static constexpr size_t min_shift = 4;
-	static constexpr size_t max_shift = 12;
-	static constexpr size_t min_size_class = size_t{1} << min_shift;
-	static constexpr size_t max_size_class = size_t{1} << max_shift;
-	static constexpr size_t num_size_classes = max_shift - min_shift + 1;
-
-	// Map a size to a bucket index. Returns the index of the smallest size class >= size.
-	static constexpr size_t bucket_index(size_t size) {
-		FRG_ASSERT(size <= max_size_class);
-		if (size < min_size_class)
-			return 0;
-		return ceil_log2(size) - min_shift;
-	}
-
-	static_assert(bucket_index(16) == 0);
-	static_assert(bucket_index(4096) == 8);
-
-	// Inverse of bucket_index().
-	static constexpr size_t size_of_bucket(size_t index) {
-		return min_size_class << index;
-	}
 
 	// Stores the address of an object as the object's offset vs. its chunk_header.
 	// This is needed to be able to compress the chunk_state struct below to a size that can be manipulated by a single CAS.
@@ -163,20 +141,20 @@ struct pool {
 	};
 
 	constexpr pool() {
-		for (size_t i = 0; i < num_size_classes; i++) {
-			buckets_[i].object_size = size_of_bucket(i);
+		for (size_t i = 0; i < policy_traits::num_buckets; i++) {
+			buckets_[i].object_size = policy_traits::bucket_to_size(i);
 		}
 	}
 
 	void *allocate(size_t size) {
 		void *obj;
-		if (size > max_size_class) {
+		if (size > policy_traits::max_bucket_size) {
 			auto result = large_allocate(size);
 			if (!result)
 				return nullptr;
 			obj = result.value();
 		} else {
-			auto idx = bucket_index(size);
+			auto idx = policy_traits::size_to_bucket(size);
 			auto result = slab_allocate(&buckets_[idx], size);
 			if (!result)
 				return nullptr;
@@ -580,7 +558,7 @@ private:
 	}
 
 	P policy_;
-	bucket buckets_[num_size_classes];
+	bucket buckets_[policy_traits::num_buckets];
 };
 
 } // namespace sharded_slab

--- a/include/frg/slab.hpp
+++ b/include/frg/slab.hpp
@@ -97,26 +97,9 @@ using policy_poison_t = decltype(std::declval<Policy>().poison(nullptr, size_t(0
 template<typename Policy>
 using policy_map_aligned_t = decltype(std::declval<Policy>().map(size_t(0), size_t(0)));
 
-template<typename Policy, typename Mutex>
-class slab_pool {
-public:
-	constexpr slab_pool(Policy &plcy);
-
-	slab_pool(const slab_pool &) = delete;
-
-	slab_pool &operator= (const slab_pool &) = delete;
-
-	void *allocate(size_t length);
-	void *realloc(void *pointer, size_t new_length);
-	void free(void *pointer);
-	void deallocate(void *pointer, size_t size);
-	size_t get_size(void *pointer);
-
-	size_t numUsedPages() {
-		return _usedPages;
-	}
-
-private:
+// Common configuration for slab allocators (slab_pool and shared_slab_pool).
+template<typename Policy>
+struct slab_policy_traits {
 	// The following variables configure the size of the buckets.
 	// Bucket size increases both with small_base_exp and small_step_exp. Furthermore,
 	// small_step_exp controls how many buckets are between any two power-of-2 buckets.
@@ -191,6 +174,29 @@ private:
 
 	static_assert(test_bucket_calculation(num_buckets),
 		"The bucket size calculation seems to be broken");
+};
+
+template<typename Policy, typename Mutex>
+class slab_pool {
+public:
+	constexpr slab_pool(Policy &plcy);
+
+	slab_pool(const slab_pool &) = delete;
+
+	slab_pool &operator= (const slab_pool &) = delete;
+
+	void *allocate(size_t length);
+	void *realloc(void *pointer, size_t new_length);
+	void free(void *pointer);
+	void deallocate(void *pointer, size_t size);
+	size_t get_size(void *pointer);
+
+	size_t numUsedPages() {
+		return _usedPages;
+	}
+
+private:
+	using policy_traits = slab_policy_traits<Policy>;
 
 	static constexpr size_t page_size = [](){
 		if constexpr (is_detected_v<policy_pagesize_t, Policy>)
@@ -329,7 +335,7 @@ private:
 	slab_frame *_construct_slab(int index);
 
 	bool reallocate_in_slab_(slab_frame *slb, void *p, size_t new_size) {
-		size_t item_size = bucket_to_size(slb->index);
+		size_t item_size = policy_traits::bucket_to_size(slb->index);
 		FRG_ASSERT(slb->contains(p));
 		FRG_ASSERT(!enable_checking
 				|| !((reinterpret_cast<uintptr_t>(p) - slb->address) % item_size));
@@ -346,7 +352,7 @@ private:
 	}
 
 	void free_in_slab_(slab_frame *slb, void *p) {
-		size_t item_size = bucket_to_size(slb->index);
+		size_t item_size = policy_traits::bucket_to_size(slb->index);
 		FRG_ASSERT(slb->contains(p));
 		FRG_ASSERT(!enable_checking
 				|| !((reinterpret_cast<uintptr_t>(p) - slb->address) % item_size));
@@ -434,7 +440,7 @@ private:
 	frame_tree_type _frame_tree;
 #endif
 	size_t _usedPages;
-	bucket _bkts[num_buckets];
+	bucket _bkts[policy_traits::num_buckets];
 };
 
 // --------------------------------------------------------
@@ -456,9 +462,9 @@ void *slab_pool<Policy, Mutex>::allocate(size_t length) {
 	if(!length)
 		length = 1;
 
-	if(length <= max_bucket_size) {
-		int index = size_to_bucket(length);
-		FRG_ASSERT(index <= num_buckets);
+	if(length <= policy_traits::max_bucket_size) {
+		int index = policy_traits::size_to_bucket(length);
+		FRG_ASSERT(index <= policy_traits::num_buckets);
 		auto bkt = &_bkts[index];
 
 		unique_lock<Mutex> bucket_guard(bkt->bucket_mutex);
@@ -567,7 +573,7 @@ void *slab_pool<Policy, Mutex>::realloc(void *p, size_t new_size) {
 		auto slb = static_cast<slab_frame *>(sup);
 		if(reallocate_in_slab_(slb, p, new_size))
 			return p;
-		current_size = bucket_to_size(slb->index);
+		current_size = policy_traits::bucket_to_size(slb->index);
 	}else{
 		FRG_ASSERT(sup->type == frame_type::large);
 		if(reallocate_huge_(sup, p, new_size))
@@ -629,7 +635,7 @@ void slab_pool<Policy, Mutex>::deallocate(void *p, size_t size) {
 	auto sup = reinterpret_cast<frame *>((address - 1) & ~(sb_size - 1));
 	if(sup->type == frame_type::slab) {
 		auto slb = static_cast<slab_frame *>(sup);
-		FRG_ASSERT(size <= bucket_to_size(slb->index));
+		FRG_ASSERT(size <= policy_traits::bucket_to_size(slb->index));
 		free_in_slab_(slb, p);
 	}else{
 		FRG_ASSERT(sup->type == frame_type::large);
@@ -654,7 +660,7 @@ size_t slab_pool<Policy, Mutex>::get_size(void *p) {
 
 	if(sup->type == frame_type::slab) {
 		auto slb = static_cast<slab_frame *>(sup);
-		return bucket_to_size(slb->index);
+		return policy_traits::bucket_to_size(slb->index);
 	}
 
 	FRG_ASSERT(sup->type == frame_type::large);
@@ -685,7 +691,7 @@ auto slab_pool<Policy, Mutex>::_construct_slab(int index)
 		address = (sb_base + sb_size - 1) & ~(sb_size - 1);
 	}
 
-	auto item_size = bucket_to_size(index);
+	auto item_size = policy_traits::bucket_to_size(index);
 	size_t overhead = 0;
 	while(overhead < sizeof(slab_frame)) // FIXME.
 		overhead += item_size;


### PR DESCRIPTION
This PR let's `sharded_slab_pool` use the same size classes as `slab_pool`. These size classes are more fine grained than the power-of-two ones that `sharded_slab` used initially.