### PR TITLE
rcu_radixtree: Add lower_bound() function for iteration across gaps

### DIFF
--- a/include/frg/rcu_radixtree.hpp
+++ b/include/frg/rcu_radixtree.hpp
@@ -333,6 +333,11 @@ public:
 			return !(*this == other);
 		}
 
+		uint64_t key() const {
+			FRG_ASSERT(_idx < 16);
+			return _n->prefix | _idx;
+		}
+
 	private:
 		entry_node *_n;
 		unsigned int _idx;
@@ -356,6 +361,72 @@ public:
 
 	iterator end() {
 		return iterator{};
+	}
+
+	// Returns an iterator to the first entry with a key >= k, or end().
+	// Like find(), this is RCU-safe.
+	iterator lower_bound(uint64_t k) {
+		// Path of link nodes from the root, together with the index we descended into.
+		// Link nodes have depths in [0, ll) and depths increase strictly along a path,
+		// hence at most ll link nodes can occur.
+		struct { link_node *node; unsigned int idx; } path[ll];
+		unsigned int height = 0;
+
+		auto n = _root.load(std::memory_order_acquire);
+		// Lower bound that applies below the current node.
+		// Raised to a subtree's prefix whenever we enter a subtree that lies entirely above k.
+		auto bound = k;
+
+		while(true) {
+			// Descend along bound, looking for the first entry that is not below it.
+			while(n) {
+				if(pfx_of(bound, n->depth) != n->prefix) {
+					// n's range is entirely below bound: backtrack.
+					if(bound > n->prefix)
+						break;
+					// n's range is entirely above bound: descend to n's leftmost entry.
+					bound = n->prefix;
+				}
+
+				if(n->depth == ll) {
+					auto cn = static_cast<entry_node *>(n);
+					auto mask = cn->mask.load(std::memory_order_acquire);
+					for(unsigned int idx = idx_of(bound, ll); idx < 16; idx++) {
+						if(mask & (uint16_t(1) << idx))
+							return iterator{cn, idx};
+					}
+					// Erasure does not remove empty nodes, so this leaf can be exhausted.
+					break;
+				}
+
+				auto cn = static_cast<link_node *>(n);
+				auto idx = idx_of(bound, cn->depth);
+				FRG_ASSERT(height < ll);
+				path[height++] = {cn, idx};
+				n = cn->links[idx].load(std::memory_order_acquire);
+			}
+
+			// Backtrack to the deepest ancestor that has a sibling above the visited one.
+			n = nullptr;
+			while(height && !n) {
+				auto &top = path[height - 1];
+				for(unsigned int idx = top.idx + 1; idx < 16; idx++) {
+					auto m = top.node->links[idx].load(std::memory_order_acquire);
+					if(m) {
+						top.idx = idx;
+						n = m;
+						break;
+					}
+				}
+				if(!n)
+					height--;
+			}
+			if(!n)
+				return iterator{};
+
+			// The sibling's subtree lies entirely above bound.
+			bound = n->prefix;
+		}
 	}
 
 private:

--- a/include/frg/rcu_radixtree.hpp
+++ b/include/frg/rcu_radixtree.hpp
@@ -289,13 +289,13 @@ private:
 	}
 
 public:
-	// Note: The iterator interface is *not* safe in the presence of concurrent modification.
+	// Note: The unsafe_iterator interface is *not* safe in the presence of concurrent modification.
 	//       Only use this interface while there are no concurrent writers.
-	struct iterator {
-		explicit iterator()
+	struct unsafe_iterator {
+		explicit unsafe_iterator()
 		: _n{nullptr}, _idx{16} { }
 
-		explicit iterator(entry_node *n, unsigned int idx)
+		explicit unsafe_iterator(entry_node *n, unsigned int idx)
 		: _n{n}, _idx{idx} { }
 
 		void operator++ () {
@@ -326,10 +326,10 @@ public:
 			return std::launder(reinterpret_cast<T *>(_n->entries[_idx].buffer));
 		}
 
-		bool operator== (const iterator &other) const {
+		bool operator== (const unsafe_iterator &other) const {
 			return _n == other._n && _idx == other._idx;
 		}
-		bool operator!= (const iterator &other) const {
+		bool operator!= (const unsafe_iterator &other) const {
 			return !(*this == other);
 		}
 
@@ -343,20 +343,82 @@ public:
 		unsigned int _idx;
 	};
 
-	iterator begin() {
+	unsafe_iterator unsafe_begin() {
 		auto n = first_leaf(_root.load(std::memory_order_relaxed));
 		while(true) {
 			if(!n)
-				return iterator{};
+				return unsafe_iterator{};
 
 			// Try to find a present entry.
 			for(unsigned int idx = 0; idx < 16; idx++) {
 				if(n->mask.load(std::memory_order_relaxed) & (1 << idx))
-					return iterator{n, idx};
+					return unsafe_iterator{n, idx};
 			}
 
 			n = next_leaf(n);
 		}
+	}
+
+	unsafe_iterator unsafe_end() {
+		return unsafe_iterator{};
+	}
+
+	// RCU-safe iterator.
+	struct iterator {
+		explicit iterator()
+		: _tree{nullptr}, _n{nullptr}, _idx{16} { }
+
+		explicit iterator(rcu_radixtree *tree, entry_node *n, unsigned int idx)
+		: _tree{tree}, _n{n}, _idx{idx} { }
+
+		void operator++ () {
+			FRG_ASSERT(_idx < 16);
+
+			// The remainder of this leaf can be scanned without descending again.
+			auto mask = _n->mask.load(std::memory_order_acquire);
+			for(unsigned int idx = _idx + 1; idx < 16; idx++) {
+				if(mask & (uint16_t(1) << idx)) {
+					_idx = idx;
+					return;
+				}
+			}
+
+			// Leaving the leaf does require a fresh descent (the links above it can change).
+			auto last = _n->prefix | 0xF;
+			if(last == uint64_t(-1)) {
+				*this = iterator{};
+				return;
+			}
+			*this = _tree->lower_bound(last + 1);
+		}
+
+		T &operator* () {
+			return *std::launder(reinterpret_cast<T *>(_n->entries[_idx].buffer));
+		}
+		T *operator-> () {
+			return std::launder(reinterpret_cast<T *>(_n->entries[_idx].buffer));
+		}
+
+		bool operator== (const iterator &other) const {
+			return _n == other._n && _idx == other._idx;
+		}
+		bool operator!= (const iterator &other) const {
+			return !(*this == other);
+		}
+
+		uint64_t key() const {
+			FRG_ASSERT(_idx < 16);
+			return _n->prefix | _idx;
+		}
+
+	private:
+		rcu_radixtree *_tree;
+		entry_node *_n;
+		unsigned int _idx;
+	};
+
+	iterator begin() {
+		return lower_bound(0);
 	}
 
 	iterator end() {
@@ -393,7 +455,7 @@ public:
 					auto mask = cn->mask.load(std::memory_order_acquire);
 					for(unsigned int idx = idx_of(bound, ll); idx < 16; idx++) {
 						if(mask & (uint16_t(1) << idx))
-							return iterator{cn, idx};
+							return iterator{this, cn, idx};
 					}
 					// Erasure does not remove empty nodes, so this leaf can be exhausted.
 					break;

--- a/include/frg/shared_ptr.hpp
+++ b/include/frg/shared_ptr.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <concepts>
+#include <utility>
 
 #include <frg/allocation.hpp>
 #include <frg/macros.hpp>
@@ -69,6 +70,12 @@ struct intrusive_shared_ptr {
 
 	T *get() const {
 		return ptr_;
+	}
+
+	// Releases ownership of the reference held by this pointer.
+	// The caller now owns the reference (i.e., the refcount is not decremented).
+	T *release() {
+		return std::exchange(ptr_, nullptr);
 	}
 
 	T *operator->() const {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,7 @@
 gtest = dependency('gtest_main')
 
 test_executable = executable('frigg_tests',
+	'rcu_radixtree.cpp',
 	'safe_int.cpp',
 	'sharded_slab.cpp',
 	'slab.cpp',

--- a/tests/rcu_radixtree.cpp
+++ b/tests/rcu_radixtree.cpp
@@ -1,0 +1,181 @@
+#include <stdint.h>
+#include <vector>
+
+#include <frg/rcu_radixtree.hpp>
+#include <frg/std_compat.hpp>
+
+#include <gtest/gtest.h>
+
+struct fake_rcu_policy {
+	template<typename T, typename D>
+	struct obj_base {
+		void retire(D d = D()) {
+			auto derived = static_cast<T *>(this);
+			d(derived);
+		}
+	};
+};
+
+using tree_type = frg::rcu_radixtree<int, frg::stl_allocator, fake_rcu_policy>;
+
+TEST(rcu_radixtree, insert_and_find) {
+	tree_type tree;
+
+	// Keys that share the same top 60 bits (same entry_node).
+	tree.insert(1, 42);
+	tree.insert(2, 100);
+	tree.insert(15, 7);
+
+	auto *p0 = tree.find(1);
+	auto *p1 = tree.find(2);
+	auto *p2 = tree.find(15);
+
+	ASSERT_NE(p0, nullptr);
+	ASSERT_NE(p1, nullptr);
+	ASSERT_NE(p2, nullptr);
+	EXPECT_EQ(*p0, 42);
+	EXPECT_EQ(*p1, 100);
+	EXPECT_EQ(*p2, 7);
+
+	// Keys that require different entry_nodes (different second-to-last nibble).
+	tree_type tree2;
+	tree2.insert(0x10, 1);
+	tree2.insert(0x20, 2);
+
+	auto *q0 = tree2.find(0x10);
+	auto *q1 = tree2.find(0x20);
+	ASSERT_NE(q0, nullptr);
+	ASSERT_NE(q1, nullptr);
+	EXPECT_EQ(*q0, 1);
+	EXPECT_EQ(*q1, 2);
+}
+
+TEST(rcu_radixtree, find_missing) {
+	tree_type tree;
+
+	tree.insert(1, 42);
+
+	EXPECT_EQ(tree.find(0), nullptr);
+	EXPECT_EQ(tree.find(2), nullptr);
+	EXPECT_EQ(tree.find(0xFFFF'FFFF'FFFF'FFFFULL), nullptr);
+}
+
+TEST(rcu_radixtree, find_or_insert_existing) {
+	tree_type tree;
+
+	auto [p1, inserted1] = tree.find_or_insert(5, 10);
+	EXPECT_TRUE(inserted1);
+	EXPECT_EQ(*p1, 10);
+
+	auto [p2, inserted2] = tree.find_or_insert(5, 99);
+	EXPECT_FALSE(inserted2);
+	EXPECT_EQ(*p2, 10);
+	EXPECT_EQ(p1, p2);
+}
+
+TEST(rcu_radixtree, erase) {
+	tree_type tree;
+
+	tree.insert(3, 42);
+	ASSERT_NE(tree.find(3), nullptr);
+
+	tree.erase(3);
+	EXPECT_EQ(tree.find(3), nullptr);
+}
+
+TEST(rcu_radixtree, iteration) {
+	tree_type tree;
+
+	tree.insert(0, 1);
+	tree.insert(1, 2);
+	tree.insert(2, 3);
+
+	int sum = 0;
+	int count = 0;
+	for (auto it = tree.begin(); it != tree.end(); ++it) {
+		sum += *it;
+		++count;
+	}
+	EXPECT_EQ(count, 3);
+	EXPECT_EQ(sum, 6);
+}
+
+TEST(rcu_radixtree, lower_bound) {
+	tree_type tree;
+
+	EXPECT_TRUE(tree.lower_bound(0) == tree.end());
+
+	// 1 and 7 share an entry_node, the other keys need their own.
+	tree.insert(1, 10);
+	tree.insert(7, 70);
+	tree.insert(0x0123'4567'89AB'CDEFULL, 80);
+	tree.insert(0xFFFF'FFFF'FFFF'FFFFULL, 90);
+
+	// Exact matches and keys that fall into the gaps.
+	EXPECT_EQ(tree.lower_bound(7).key(), 7u);
+	EXPECT_EQ(tree.lower_bound(0).key(), 1u);
+	EXPECT_EQ(*tree.lower_bound(2), 70);
+	EXPECT_EQ(tree.lower_bound(8).key(), 0x0123'4567'89AB'CDEFULL);
+	EXPECT_EQ(tree.lower_bound(0x0123'4567'89AB'CDF0ULL).key(), 0xFFFF'FFFF'FFFF'FFFFULL);
+
+	// Incrementing past the largest possible key must not wrap around.
+	auto it = tree.lower_bound(0xFFFF'FFFF'FFFF'FFFFULL);
+	++it;
+	EXPECT_TRUE(it == tree.end());
+}
+
+TEST(rcu_radixtree, lower_bound_empty_entry_node) {
+	tree_type tree;
+
+	tree.insert(0x100, 1);
+	tree.insert(0x500, 2);
+
+	// Erasure does not remove the entry_node, hence lower_bound() has to skip the
+	// empty node that is left behind.
+	tree.erase(0x100);
+
+	EXPECT_EQ(tree.lower_bound(0).key(), 0x500u);
+	EXPECT_EQ(tree.lower_bound(0x100).key(), 0x500u);
+	EXPECT_TRUE(tree.lower_bound(0x501) == tree.end());
+}
+
+TEST(rcu_radixtree, lower_bound_deep_backtracking) {
+	tree_type tree;
+
+	// Keys that differ from zero only in nibble d yield a link_node at depth d,
+	// i.e., inserting all of them builds a tree of maximal height.
+	tree.insert(0, 0);
+	for (unsigned int d = 0; d < 15; d++)
+		tree.insert(uint64_t(1) << (64 - (d + 1) * 4), 1);
+
+	// Erase everything but the largest key: lower_bound() now has to backtrack over
+	// the full height of the tree.
+	tree.erase(0);
+	for (unsigned int d = 1; d < 15; d++)
+		tree.erase(uint64_t(1) << (64 - (d + 1) * 4));
+
+	EXPECT_EQ(tree.lower_bound(0).key(), uint64_t(1) << 60);
+	EXPECT_TRUE(tree.lower_bound((uint64_t(1) << 60) + 1) == tree.end());
+}
+
+TEST(rcu_radixtree, iteration_across_entry_nodes) {
+	tree_type tree;
+
+	EXPECT_TRUE(tree.unsafe_begin() == tree.unsafe_end());
+
+	tree.insert(1, 1);
+	tree.insert(0x10, 2);
+	tree.insert(0xFFFF'FFFF'FFFF'FFFFULL, 3);
+
+	std::vector<uint64_t> expected{1, 0x10, 0xFFFF'FFFF'FFFF'FFFFULL};
+
+	std::vector<uint64_t> keys;
+	for (auto it = tree.begin(); it != tree.end(); ++it)
+		keys.push_back(it.key());
+	EXPECT_EQ(keys, expected);
+
+	keys.clear();
+	for (auto it = tree.unsafe_begin(); it != tree.unsafe_end(); ++it)
+		keys.push_back(it.key());
+	EXPECT_EQ(keys, expected);
+}


### PR DESCRIPTION
Add an efficient way to iterate over gaps in a `frg::rcu_radixtree`.